### PR TITLE
Add info and upgrade libs and confluent version

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,10 +62,11 @@ docker-compose -f docker-compose.yml -f docker-compose-ksql.yml -f docker-compos
 ```
 
 Steps to test:
+1. Navigate to http://localhost:18080 and login using __postgres__ as server, __postgres__ as username and __example__ as password
 
-1. Create a Table "source_table" in the Postgres Database in http://localhost:18080
+2. Create a table "source_table" with an auto-increment __id__ and __name__ field
 
-2. Once database is created deploy source and sink connectors using Makefile: 
+3. Once table is created deploy source and sink connectors using Makefile: 
 
 ```bash
 make source-connector

--- a/docker-compose-connectors.yml
+++ b/docker-compose-connectors.yml
@@ -16,7 +16,7 @@
 version: '3'
 services:
   jdbc-source-connect:
-    image: confluentinc/cp-kafka-connect:5.0.0
+    image: confluentinc/cp-kafka-connect:5.3.1
     ports:
       - 8083:8083
     environment:
@@ -42,10 +42,10 @@ services:
         'no.sysco.middleware.kafka.interceptor.zipkin.TracingProducerInterceptor'
       CONNECT_PRODUCER_ZIPKIN_LOCAL_SERVICE_NAME: "jdbc-source-connect"
     volumes:
-      - ./target/kafka-interceptor-zipkin-0.4.0-SNAPSHOT.jar:/etc/kafka-connect/jars/kafka-interceptor-zipkin.jar
+      - ./target/kafka-interceptor-zipkin-0.4.3-SNAPSHOT.jar:/etc/kafka-connect/jars/kafka-interceptor-zipkin.jar
 
   jdbc-sink-connect:
-    image: confluentinc/cp-kafka-connect:5.0.0
+    image: confluentinc/cp-kafka-connect:5.3.1
     ports:
       - 8084:8084
     environment:
@@ -71,7 +71,7 @@ services:
       CONNECT_CONSUMER_INTERCEPTOR_CLASSES:
         'no.sysco.middleware.kafka.interceptor.zipkin.TracingConsumerInterceptor'
     volumes:
-      - ./target/kafka-interceptor-zipkin-0.4.0-SNAPSHOT.jar:/etc/kafka-connect/jars/kafka-interceptor-zipkin.jar
+      - ./target/kafka-interceptor-zipkin-0.4.3-SNAPSHOT.jar:/etc/kafka-connect/jars/kafka-interceptor-zipkin.jar
 
   postgres:
     image: postgres

--- a/docker-compose-ksql.yml
+++ b/docker-compose-ksql.yml
@@ -16,7 +16,7 @@
 version: '3'
 services:
   ksql-server:
-    image: confluentinc/cp-ksql-server:5.0.0
+    image: confluentinc/cp-ksql-server:5.3.1
     ports:
       - 8088:8088
     depends_on:
@@ -27,8 +27,9 @@ services:
       KSQL_LISTENERS: http://0.0.0.0:8088
       KSQL_KSQL_SCHEMA_REGISTRY_URL: http://schema-registry:8081
       KSQL_KSQL_SERVICE_ID: ksql
-      KSQL_CONSUMER_ZIPKIN_SENDER_TYPE: "KAFKA"
-      KSQL_CONSUMER_ZIPKIN_LOCAL_SERVICE_NAME: "ksql"
       KSQL_CONSUMER_INTERCEPTOR_CLASSES: "no.sysco.middleware.kafka.interceptor.zipkin.TracingConsumerInterceptor"
+      # Removed 'CONSUMER' from the following 2 Zipkin environment variables.
+      KSQL_ZIPKIN_SENDER_TYPE: "KAFKA" 
+      KSQL_ZIPKIN_LOCAL_SERVICE_NAME: "ksql"
     volumes:
-      - ./target/kafka-interceptor-zipkin-0.4.0-SNAPSHOT.jar:/usr/share/java/ksql-server/kafka-interceptor-zipkin.jar
+      - ./target/kafka-interceptor-zipkin-0.4.3-SNAPSHOT.jar:/usr/share/java/ksql-server/kafka-interceptor-zipkin.jar

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,14 +17,14 @@ version: '3'
 services:
   # Kafka Cluster
   zookeeper:
-    image: confluentinc/cp-zookeeper:5.0.0
+    image: confluentinc/cp-zookeeper:5.3.1
     ports:
       - 2181:2181
     environment:
       ZOOKEEPER_CLIENT_PORT: 2181
       ZOOKEEPER_TICK_TIME: 2000
   kafka:
-    image: confluentinc/cp-kafka:5.0.0
+    image: confluentinc/cp-kafka:5.3.1
     ports:
       - 9092:9092
       - 29092:29092
@@ -39,7 +39,7 @@ services:
       - zookeeper
   # Zipkin
   zipkin:
-    image: openzipkin/zipkin:2.12
+    image: openzipkin/zipkin:2.17.1
     environment:
       STORAGE_TYPE: mem
       KAFKA_BOOTSTRAP_SERVERS: kafka:9092

--- a/pom.xml
+++ b/pom.xml
@@ -49,8 +49,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <kafka.version>2.1.1</kafka.version>
-        <brave.version>5.6.0</brave.version>
+        <kafka.version>2.3.0</kafka.version>
+        <brave.version>5.8.0</brave.version>
         <junit.version>4.12</junit.version>
     </properties>
 
@@ -58,7 +58,7 @@
         <dependencies>
             <dependency>
                 <groupId>io.zipkin.brave</groupId>
-                <artifactId>brave-bom</artifactId>
+                <artifactId>brave</artifactId>
                 <version>${brave.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
@@ -71,15 +71,18 @@
         <dependency>
             <groupId>io.zipkin.brave</groupId>
             <artifactId>brave-instrumentation-kafka-clients</artifactId>
+            <version>5.8.0</version>
         </dependency>
         <!-- Zipkin sender supported -->
         <dependency>
             <groupId>io.zipkin.reporter2</groupId>
             <artifactId>zipkin-sender-okhttp3</artifactId>
+            <version>2.10.3</version>
         </dependency>
         <dependency>
             <groupId>io.zipkin.reporter2</groupId>
-            <artifactId>zipkin-sender-kafka11</artifactId>
+            <artifactId>zipkin-sender-kafka</artifactId>
+            <version>2.10.3</version>
         </dependency>
 
         <!-- Kafka Clients dependency that will be provided by application -->

--- a/src/main/java/no/sysco/middleware/kafka/interceptor/zipkin/TracingBuilder.java
+++ b/src/main/java/no/sysco/middleware/kafka/interceptor/zipkin/TracingBuilder.java
@@ -22,7 +22,7 @@ import zipkin2.Span;
 import zipkin2.codec.Encoding;
 import zipkin2.reporter.AsyncReporter;
 import zipkin2.reporter.Sender;
-import zipkin2.reporter.kafka11.KafkaSender;
+import zipkin2.reporter.kafka.KafkaSender;
 import zipkin2.reporter.okhttp3.OkHttpSender;
 
 import static no.sysco.middleware.kafka.interceptor.zipkin.TracingConfiguration.ENCODING_CONFIG;
@@ -32,8 +32,6 @@ import static no.sysco.middleware.kafka.interceptor.zipkin.TracingConfiguration.
 import static no.sysco.middleware.kafka.interceptor.zipkin.TracingConfiguration.KAFKA_BOOTSTRAP_SERVERS_CONFIG;
 import static no.sysco.middleware.kafka.interceptor.zipkin.TracingConfiguration.LOCAL_SERVICE_NAME_CONFIG;
 import static no.sysco.middleware.kafka.interceptor.zipkin.TracingConfiguration.LOCAL_SERVICE_NAME_DEFAULT;
-import static no.sysco.middleware.kafka.interceptor.zipkin.TracingConfiguration.REMOTE_SERVICE_NAME_CONFIG;
-import static no.sysco.middleware.kafka.interceptor.zipkin.TracingConfiguration.REMOTE_SERVICE_NAME_DEFAULT;
 import static no.sysco.middleware.kafka.interceptor.zipkin.TracingConfiguration.SAMPLER_RATE_CONFIG;
 import static no.sysco.middleware.kafka.interceptor.zipkin.TracingConfiguration.SAMPLER_RATE_DEFAULT;
 import static no.sysco.middleware.kafka.interceptor.zipkin.TracingConfiguration.SENDER_TYPE_CONFIG;

--- a/src/test/java/no/sysco/middleware/kafka/interceptor/zipkin/TracingBuilderTest.java
+++ b/src/test/java/no/sysco/middleware/kafka/interceptor/zipkin/TracingBuilderTest.java
@@ -21,7 +21,7 @@ import org.apache.kafka.clients.CommonClientConfigs;
 import org.junit.Test;
 import zipkin2.codec.Encoding;
 import zipkin2.reporter.Sender;
-import zipkin2.reporter.kafka11.KafkaSender;
+import zipkin2.reporter.kafka.KafkaSender;
 import zipkin2.reporter.okhttp3.OkHttpSender;
 
 import static no.sysco.middleware.kafka.interceptor.zipkin.TracingConfiguration.ENCODING_CONFIG;

--- a/src/test/java/no/sysco/middleware/kafka/interceptor/zipkin/TracingConfigurationTest.java
+++ b/src/test/java/no/sysco/middleware/kafka/interceptor/zipkin/TracingConfigurationTest.java
@@ -13,12 +13,12 @@
  */
 package no.sysco.middleware.kafka.interceptor.zipkin;
 
-import java.util.AbstractList;
+import org.junit.Test;
+
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;

--- a/src/test/java/no/sysco/middleware/kafka/interceptor/zipkin/TracingProducerInterceptorTest.java
+++ b/src/test/java/no/sysco/middleware/kafka/interceptor/zipkin/TracingProducerInterceptorTest.java
@@ -50,13 +50,11 @@ public class TracingProducerInterceptorTest extends BaseTracingTest {
 	@Test
 	public void shouldCreateChildSpanIfContextAvailable() {
 		// Given
-		final TracingProducerInterceptor<String, String> interceptor =
-				new TracingProducerInterceptor<>();
+		final TracingProducerInterceptor<String, String> interceptor = new TracingProducerInterceptor<>();
 		interceptor.configure(map);
 		interceptor.tracing = tracing;
 		brave.Span span = tracing.tracer().newTrace();
-		tracing.propagation()
-				.injector(KafkaInterceptorPropagation.HEADER_SETTER)
+		tracing.propagation().injector(KafkaInterceptorPropagation.HEADER_SETTER)
 				.inject(span.context(), record.headers());
 		// When
 		interceptor.onSend(record);


### PR DESCRIPTION
This change:
1. Add more information on how to run the demo.
2. Upgrade confluent version to 5.3.1 and java libs.
3. Change docker-compose files to use the latest jar and fix ZIPKIN
environment variables.

Issue:
ZIPKIN properties in KSQL were not propagated to the interceptors
because of a known bug: https://github.com/confluentinc/ksql/issues/2279