### PR TITLE
chore: bump versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ pg-table:
 .PHONY: kafka-connectors
 kafka-connectors:
 	curl -XPUT -H 'Content-Type:application/json' -d @docker/kafka-connector/jdbc-source.json http://localhost:8083/connectors/jdbc_source/config
-	curl -XPUT -H 'Content-Type:application/json' -d @docker/kafka-connector/jdbc-sink.json http://localhost:8084/connectors/jdbc_sink/config
+	curl -XPUT -H 'Content-Type:application/json' -d @docker/kafka-connector/jdbc-sink.json http://localhost:8083/connectors/jdbc_sink/config
 
 .PHONY: pg-row
 pg-row:
@@ -40,6 +40,9 @@ ksql-stream:
 ksql-select:
 	docker-compose exec ksql-cli bash -c \
 		'echo -e "\
-		SELECT id, name FROM source_stream EMIT CHANGES;" \
+		CREATE STREAM another_stream \
+		AS SELECT id, name \
+		FROM source_stream \
+		EMIT CHANGES;" \
 		| ksql http://ksql-server:8088'
 

--- a/README.md
+++ b/README.md
@@ -1,21 +1,23 @@
 [![Gitter chat](http://img.shields.io/badge/gitter-join%20chat%20%E2%86%92-brightgreen.svg)](https://gitter.im/openzipkin/zipkin)
 [![Build Status](https://www.travis-ci.org/openzipkin-contrib/brave-kafka-interceptor.svg?branch=master)](https://www.travis-ci.org/openzipkin-contrib/brave-kafka-interceptor)
 
-# Kafka Interceptor: Zipkin
+# Brave: Kafka Interceptor
 
 Kafka [Consumer](https://kafka.apache.org/0100/javadoc/org/apache/kafka/clients/consumer/ConsumerInterceptor.html)
 and
 [Producer](https://kafka.apache.org/0100/javadoc/org/apache/kafka/clients/producer/ProducerInterceptor.html)
-Interceptor to record tracing data.
+Interceptors for tracing and report to Zipkin.
 
-This interceptors could be added to Kafka Connectors via configuration and to other off-the-shelf
-components like Kafka REST Proxy, KSQL and so on.
+These interceptors could be plugged into Kafka applications via classpath configuration.
+
+The purpose of this instrumentation is to enable tracing for Kafka Connect and other off-the-shelf components like Kafka REST Proxy, ksqlDB, etc.
+For more complete tracing support, check [Brave instrumentation](https://github.com/openzipkin/brave) for [Kafka Clients](https://github.com/openzipkin/brave/tree/master/instrumentation/kafka-clients) and [Kafka Streams](https://github.com/openzipkin/brave/tree/master/instrumentation/kafka-streams).
 
 ## Installation
 
 ### Producer Interceptor
 
-Producer Interceptor create spans on sending records. This span will only represent the time it took to
+Producer Interceptor create spans when sending records. This span will only represent the time it took to
 execute the `on_send` method provided by the API, not how long to send the actual record, or any other latency.
 
 #### Kafka Clients

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -83,10 +83,11 @@ services:
       CONNECT_INTERNAL_KEY_CONVERTER: org.apache.kafka.connect.json.JsonConverter
       CONNECT_INTERNAL_VALUE_CONVERTER: org.apache.kafka.connect.json.JsonConverter
       CONNECT_PLUGIN_PATH: /usr/share/java
-      CONNECT_PRODUCER_ZIPKIN_SENDER_TYPE: HTTP
-      CONNECT_PRODUCER_ZIPKIN_HTTP_ENDPOINT: http://zipkin:9411/api/v2/spans
       CONNECT_PRODUCER_INTERCEPTOR_CLASSES: brave.kafka.interceptor.TracingProducerInterceptor
-      CONNECT_PRODUCER_ZIPKIN_LOCAL_SERVICE_NAME: jdbc-source-connect
+      CONNECT_CONNECTOR_CLIENT_CONFIG_OVERRIDE_POLICY: All
+#      CONNECT_PRODUCER_ZIPKIN_LOCAL_SERVICE_NAME: jdbc-source-connect
+#      CONNECT_PRODUCER_ZIPKIN_SENDER_TYPE: HTTP
+#      CONNECT_PRODUCER_ZIPKIN_HTTP_ENDPOINT: http://zipkin:9411/api/v2/spans
     volumes:
       - ./target/brave-kafka-interceptor-0.5.5-SNAPSHOT.jar:/etc/kafka-connect/jars/brave-kafka-interceptor.jar
 
@@ -112,10 +113,11 @@ services:
       CONNECT_INTERNAL_KEY_CONVERTER: org.apache.kafka.connect.json.JsonConverter
       CONNECT_INTERNAL_VALUE_CONVERTER: org.apache.kafka.connect.json.JsonConverter
       CONNECT_PLUGIN_PATH: /usr/share/java
-      CONNECT_CONSUMER_ZIPKIN_LOCAL_SERVICE_NAME: jdbc-sink-connect
-      CONNECT_CONSUMER_ZIPKIN_SENDER_TYPE: HTTP
-      CONNECT_CONSUMER_ZIPKIN_HTTP_ENDPOINT: http://zipkin:9411/api/v2/spans
       CONNECT_CONSUMER_INTERCEPTOR_CLASSES: brave.kafka.interceptor.TracingConsumerInterceptor
+      CONNECT_CONNECTOR_CLIENT_CONFIG_OVERRIDE_POLICY: All
+#      CONNECT_CONSUMER_ZIPKIN_LOCAL_SERVICE_NAME: jdbc-sink-connect
+#      CONNECT_CONSUMER_ZIPKIN_SENDER_TYPE: HTTP
+#      CONNECT_CONSUMER_ZIPKIN_HTTP_ENDPOINT: http://zipkin:9411/api/v2/spans
     volumes:
       - ./target/brave-kafka-interceptor-0.5.5-SNAPSHOT.jar:/etc/kafka-connect/jars/brave-kafka-interceptor.jar
   ### KSQL

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,14 +16,14 @@
 version: '3'
 services:
   zookeeper:
-    image: confluentinc/cp-zookeeper
+    image: confluentinc/cp-zookeeper:5.5.0
     ports:
       - 2181:2181
     environment:
       ZOOKEEPER_CLIENT_PORT: 2181
       ZOOKEEPER_TICK_TIME: 2000
   kafka:
-    image: confluentinc/cp-kafka
+    image: confluentinc/cp-kafka:5.5.0
     ports:
       - 9092:9092
       - 29092:29092
@@ -34,6 +34,8 @@ services:
       KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092,PLAINTEXT_HOST://localhost:29092
       KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
       KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
     depends_on:
       - zookeeper
   zipkin:
@@ -61,8 +63,8 @@ services:
     environment:
       SCHEMA_REGISTRY_HOST_NAME: schema-registry
       SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS: kafka:9092
-  jdbc-source-connect:
-    image: confluentinc/cp-kafka-connect
+  connect:
+    image: confluentinc/cp-kafka-connect:5.5.0
     ports:
       - 8083:8083
     environment:
@@ -71,11 +73,11 @@ services:
       CONNECT_REST_PORT: 8083
       CONNECT_GROUP_ID: jdbc-source-connect
       CONNECT_OFFSET_FLUSH_INTERVAL_MS: 10000
-      CONNECT_CONFIG_STORAGE_TOPIC: jdbc-source-connect-configs
+      CONNECT_CONFIG_STORAGE_TOPIC: connect-configs
       CONNECT_CONFIG_STORAGE_REPLICATION_FACTOR: 1
-      CONNECT_OFFSET_STORAGE_TOPIC: jdbc-source-connect-offsets
+      CONNECT_OFFSET_STORAGE_TOPIC: connect-offsets
       CONNECT_OFFSET_STORAGE_REPLICATION_FACTOR: 1
-      CONNECT_STATUS_STORAGE_TOPIC: jdbc-source-connect-status
+      CONNECT_STATUS_STORAGE_TOPIC: connect-status
       CONNECT_STATUS_STORAGE_REPLICATION_FACTOR: 1
       CONNECT_KEY_CONVERTER: org.apache.kafka.connect.storage.StringConverter
       CONNECT_VALUE_CONVERTER: io.confluent.connect.avro.AvroConverter
@@ -84,45 +86,13 @@ services:
       CONNECT_INTERNAL_VALUE_CONVERTER: org.apache.kafka.connect.json.JsonConverter
       CONNECT_PLUGIN_PATH: /usr/share/java
       CONNECT_PRODUCER_INTERCEPTOR_CLASSES: brave.kafka.interceptor.TracingProducerInterceptor
-      CONNECT_CONNECTOR_CLIENT_CONFIG_OVERRIDE_POLICY: All
-#      CONNECT_PRODUCER_ZIPKIN_LOCAL_SERVICE_NAME: jdbc-source-connect
-#      CONNECT_PRODUCER_ZIPKIN_SENDER_TYPE: HTTP
-#      CONNECT_PRODUCER_ZIPKIN_HTTP_ENDPOINT: http://zipkin:9411/api/v2/spans
-    volumes:
-      - ./target/brave-kafka-interceptor-0.5.5-SNAPSHOT.jar:/etc/kafka-connect/jars/brave-kafka-interceptor.jar
-
-  jdbc-sink-connect:
-    image: confluentinc/cp-kafka-connect
-    ports:
-      - 8084:8084
-    environment:
-      CONNECT_BOOTSTRAP_SERVERS: kafka:9092
-      CONNECT_REST_ADVERTISED_HOST_NAME: localhost
-      CONNECT_REST_PORT: 8084
-      CONNECT_GROUP_ID: jdbc-sink-connect
-      CONNECT_OFFSET_FLUSH_INTERVAL_MS: 10000
-      CONNECT_CONFIG_STORAGE_TOPIC: jdbc-sink-connect-configs
-      CONNECT_CONFIG_STORAGE_REPLICATION_FACTOR: 1
-      CONNECT_OFFSET_STORAGE_TOPIC: jdbc-sink-connect-offsets
-      CONNECT_OFFSET_STORAGE_REPLICATION_FACTOR: 1
-      CONNECT_STATUS_STORAGE_TOPIC: jdbc-sink-connect-status
-      CONNECT_STATUS_STORAGE_REPLICATION_FACTOR: 1
-      CONNECT_KEY_CONVERTER: org.apache.kafka.connect.storage.StringConverter
-      CONNECT_VALUE_CONVERTER: io.confluent.connect.avro.AvroConverter
-      CONNECT_VALUE_CONVERTER_SCHEMA_REGISTRY_URL: http://schema-registry:8081
-      CONNECT_INTERNAL_KEY_CONVERTER: org.apache.kafka.connect.json.JsonConverter
-      CONNECT_INTERNAL_VALUE_CONVERTER: org.apache.kafka.connect.json.JsonConverter
-      CONNECT_PLUGIN_PATH: /usr/share/java
       CONNECT_CONSUMER_INTERCEPTOR_CLASSES: brave.kafka.interceptor.TracingConsumerInterceptor
       CONNECT_CONNECTOR_CLIENT_CONFIG_OVERRIDE_POLICY: All
-#      CONNECT_CONSUMER_ZIPKIN_LOCAL_SERVICE_NAME: jdbc-sink-connect
-#      CONNECT_CONSUMER_ZIPKIN_SENDER_TYPE: HTTP
-#      CONNECT_CONSUMER_ZIPKIN_HTTP_ENDPOINT: http://zipkin:9411/api/v2/spans
     volumes:
       - ./target/brave-kafka-interceptor-0.5.5-SNAPSHOT.jar:/etc/kafka-connect/jars/brave-kafka-interceptor.jar
   ### KSQL
   ksql-server:
-    image: confluentinc/cp-ksql-server
+    image: confluentinc/cp-ksqldb-server:5.5.0
     ports:
       - 8088:8088
     depends_on:
@@ -138,9 +108,9 @@ services:
       KSQL_ZIPKIN_SENDER_TYPE: KAFKA
       KSQL_ZIPKIN_LOCAL_SERVICE_NAME: ksql
     volumes:
-      - ./target/brave-kafka-interceptor-0.5.5-SNAPSHOT.jar:/usr/share/java/ksql-server/brave-kafka-interceptor.jar
+      - ./target/brave-kafka-interceptor-0.5.5-SNAPSHOT.jar:/usr/share/java/ksqldb-server/brave-kafka-interceptor.jar
   ksql-cli:
-    image: confluentinc/cp-ksql-cli
+    image: confluentinc/cp-ksqldb-cli:5.5.0
     depends_on:
       - ksql-server
     entrypoint: /bin/sh

--- a/docker/kafka-connector/jdbc-sink.json
+++ b/docker/kafka-connector/jdbc-sink.json
@@ -7,5 +7,8 @@
   "connection.password": "example",
   "auto.create": "true",
   "table.prefix": "sink_",
-  "errors.log.enable": true
+  "errors.log.enable": true,
+  "consumer.override.zipkin.local.service.name": "jdbc-sink-connect",
+  "consumer.override.zipkin.sender.type": "HTTP",
+  "consumer.override.zipkin.http.endpoint": "http://zipkin:9411/api/v2/spans"
 }

--- a/docker/kafka-connector/jdbc-source.json
+++ b/docker/kafka-connector/jdbc-source.json
@@ -8,5 +8,8 @@
   "table.whitelist": "source_table",
   "mode": "incrementing",
   "incrementing.column.name": "id",
-  "errors.log.enable": true
+  "errors.log.enable": true,
+  "producer.override.zipkin.local.service.name": "jdbc-source-connect",
+  "producer.override.zipkin.sender.type": "HTTP",
+  "producer.override.zipkin.http.endpoint": "http://zipkin:9411/api/v2/spans"
 }

--- a/pom.xml
+++ b/pom.xml
@@ -84,11 +84,11 @@
 
     <main.basedir>${project.basedir}</main.basedir>
 
-    <kafka.version>2.3.0</kafka.version>
-    <brave.version>5.9.2</brave.version>
-    <junit-jupiter.version>5.5.2</junit-jupiter.version>
-    <testcontainers.version>1.12.1</testcontainers.version>
-    <assertj.version>3.13.2</assertj.version>
+    <kafka.version>2.5.0</kafka.version>
+    <brave.version>5.12.3</brave.version>
+    <junit-jupiter.version>5.6.2</junit-jupiter.version>
+    <testcontainers.version>1.14.3</testcontainers.version>
+    <assertj.version>3.16.1</assertj.version>
 
     <!-- override to set exclusions per-project -->
     <errorprone.args />


### PR DESCRIPTION
# Changes
* Upgrade versions, mainly Brave and Kafka.
* Support connector overrides to simplify compose.
Connectors now support an override policy to set tracer props easily per conenctor, no need for two connectors for demo purposes now.